### PR TITLE
[draytonwiser] fix represenation property

### DIFF
--- a/bundles/org.openhab.binding.draytonwiser/README.md
+++ b/bundles/org.openhab.binding.draytonwiser/README.md
@@ -7,22 +7,23 @@ The integration happens through the HeatHub, which acts as an IP gateway to the 
 
 The Drayton Wiser binding supports the following things:
 
-* Bridge - The network device in the controller that allows us to interact with the other devices in the system
-* Boiler Controller - The _HeatHub_ attached to the boiler. This also acts as the hub device.
-* Rooms - Virtual groups of _Room Thermostats_ and _TRVs_ that can have temperatures and humidities
-* Room Thermostats - Wireless thermostats which monitor temperature and humidity, and call for heat
-* Smart TRVs - Wireless TRVs that monitor temperature, alter the radiator valve state and call for heat
-* Hot Water - Virtual thing to manage hot water states
-* Smart Plugs - Wireless plug sockets which can be remotely switched
+| Bridge    | Label   | Description                                                                                          |
+|-----------|---------|------------------------------------------------------------------------------------------------------|
+| `heathub` | HeatHub | The network device in the controller that allows us to interact with the other devices in the system |
+
+| Thing               | Label             | Description                                                                               |
+|---------------------|-------------------|-------------------------------------------------------------------------------------------|
+| `boiler-controller` | Boiler Controller | The _HeatHub_ attached to the boiler. This also acts as the hub device                    |
+| `room`              | Room Name         | Virtual groups of _Room Thermostats_ and _TRVs_ that can have temperatures and humidities |
+| `roomstat`          | Thermostat        | Wireless thermostats which monitor temperature and humidity, and call for heat            |
+| `itrv`              | iTRV              | Wireless TRVs that monitor temperature, alter the radiator valve state and call for heat  |
+| `hotwater`          | Hot Water         | Virtual thing to manage hot water states                                                  |
+| `smart-plug`        | Smart Plug        | Wireless plug sockets which can be remotely switched                                      |
 
 ## Discovery
 
 The HeatHub can be discovered automatically via mDNS, however the `secret` cannot be determined automatically.
 Once the `secret` has been configured, all other devices can be discovered by triggering device discovery again.
-
-## Binding Configuration
-
-None required
 
 ## Thing Configuration
 
@@ -110,28 +111,28 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 
 #### Smart Plug
 
-| Channel             | Item Type    | Description                        |
-|---------------------|--------------|------------------------------------|
-| `currentSignalRSSI` | Number       | Relative Signal Strength Indicator |
-| `currentSignalLQI`  | Number       | Link Quality Indicator             |
-| `zigbeeConnected`   | Switch       | Is the TRV joined to network       |
+| Channel             | Item Type | Description                        |
+|---------------------|-----------|------------------------------------|
+| `currentSignalRSSI` | Number    | Relative Signal Strength Indicator |
+| `currentSignalLQI`  | Number    | Link Quality Indicator             |
+| `zigbeeConnected`   | Switch    | Is the TRV joined to network       |
 
 ### Command Channels
 
 #### Boiler Controller
 
-| Channel         | Item Type    | Description                |
-|-----------------|--------------|----------------------------|
-| `awayModeState` | Switch       | Has away mode been enabled |
-| `ecoModeState`  | Switch       | Has eco mode been enabled  |
+| Channel         | Item Type | Description                |
+|-----------------|-----------|----------------------------|
+| `awayModeState` | Switch    | Has away mode been enabled |
+| `ecoModeState`  | Switch    | Has eco mode been enabled  |
 
 #### Hot Water
 
-| Channel                 | Item Type    | Description                                |
-|-------------------------|--------------|--------------------------------------------|
-| `manualModeState`       | Switch       | Has manual mode been enabled               |
-| `hotWaterSetPoint`      | Switch       | The current hot water setpoint (on or off) |
-| `hotWaterBoostDuration` | Number       | Period in hours to boost the hot water     |
+| Channel                 | Item Type | Description                                |
+|-------------------------|-----------|--------------------------------------------|
+| `manualModeState`       | Switch    | Has manual mode been enabled               |
+| `hotWaterSetPoint`      | Switch    | The current hot water setpoint (on or off) |
+| `hotWaterBoostDuration` | Number    | Period in hours to boost the hot water     |
 
 #### Room
 
@@ -144,24 +145,24 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 
 #### Room Stat
 
-| Channel        | Item Type    | Description                      |
-|----------------|--------------|----------------------------------|
-| `deviceLocked` | Switch       | Is the roomstat interface locked |
+| Channel        | Item Type | Description                      |
+|----------------|-----------|----------------------------------|
+| `deviceLocked` | Switch    | Is the roomstat interface locked |
 
 #### Smart TRV
 
-| Channel        | Item Type    | Description                 |
-|----------------|--------------|-----------------------------|
-| `deviceLocked` | Switch       | Are the TRV controls locked |
+| Channel        | Item Type | Description                 |
+|----------------|-----------|-----------------------------|
+| `deviceLocked` | Switch    | Are the TRV controls locked |
 
 #### Smart Plug
 
-| Channel           | Item Type    | Description                                  |
-|-------------------|--------------|----------------------------------------------|
-| `plugOutputState` | Switch       | The current on/off state of the smart plug   |
-| `plugAwayAction`  | Switch       | Should the plug switch off when in away mode |
-| `manualModeState` | Switch       | Has manual mode been enabled                 |
-| `deviceLocked`    | Switch       | Are the Smart Plug controls locked           |
+| Channel           | Item Type | Description                                  |
+|-------------------|-----------|----------------------------------------------|
+| `plugOutputState` | Switch    | The current on/off state of the smart plug   |
+| `plugAwayAction`  | Switch    | Should the plug switch off when in away mode |
+| `manualModeState` | Switch    | Has manual mode been enabled                 |
+| `deviceLocked`    | Switch    | Are the Smart Plug controls locked           |
 
 #### Known string responses for specific channels:
 
@@ -175,16 +176,15 @@ The `awaySetPoint` defines the temperature in degrees Celsius that will be sent 
 ### .things file
 
 ```
-Bridge draytonwiser:heathub:HeatHub [ networkAddress="192.168.1.X", refresh=60, secret="secret from hub", awaySetPoint=10 ]
-{
-	boiler-controller controller     "Controller"
-	room              livingroom     "Living Room"            [ name="Living Room" ]
-	room              bathroom       "Bathroom"               [ name="Bathroom" ]
-	room              bedroom        "Bedroom"                [ name="Bedroom" ]
-	roomstat          livingroomstat "Living Room Thermostat" [ serialNumber="ABCDEF1234" ]
-	itrv              livingroomtrv  "Living Room - TRV"      [ serialNumber="ABCDEF1235" ]
-	hotwater          hotwater
-    smart-plug        tvplug [ serialNumber="ABCDEF1236" ]
+Bridge draytonwiser:heathub:HeatHub [ networkAddress="192.168.1.X", refresh=60, secret="secret from hub", awaySetPoint=10 ] {
+    boiler-controller controller     "Controller"
+    room              livingroom     "Living Room"            [ name="Living Room" ]
+    room              bathroom       "Bathroom"               [ name="Bathroom" ]
+    room              bedroom        "Bedroom"                [ name="Bedroom" ]
+    roomstat          livingroomstat "Living Room Thermostat" [ serialNumber="ABCDEF1234" ]
+    itrv              livingroomtrv  "Living Room - TRV"      [ serialNumber="ABCDEF1235" ]
+    hotwater          hotwater       "Hot Water"
+    smart-plug        tvplug         "TV"                     [ serialNumber="ABCDEF1236" ]
 }
 ```
 
@@ -235,14 +235,14 @@ Number:Humidity livingroom_humidity  "Humidity [%.0f %%]" <humidity> (GF_Living)
 
 ```
 Text label="Living Room" icon="sofa" {
-				Text item=livingroom_temperature
-				Setpoint item=livingroom_setpoint step=0.5
-				Text item=livingroom_humidity
-				Text item=Heating_GF_Living
-				Text item=livingroom_heatdemand
-				Switch item=ManualMode_GF_Living
-				Text item=BoostMode_GF_Living
-				Switch item=BoostDuration_GF_Living icon="time" mappings=[0="0", 0.5="0.5", 1="1", 2="2", 3="3"]
-				Text item=BoostRemaining_GF_Living icon="time"
-			}
+    Text item=livingroom_temperature
+    Setpoint item=livingroom_setpoint step=0.5
+    Text item=livingroom_humidity
+    Text item=Heating_GF_Living
+    Text item=livingroom_heatdemand
+    Switch item=ManualMode_GF_Living
+    Text item=BoostMode_GF_Living
+    Switch item=BoostDuration_GF_Living icon="time" mappings=[0="0", 0.5="0.5", 1="1", 2="2", 3="3"]
+    Text item=BoostRemaining_GF_Living icon="time"
+}
 ```

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/DraytonWiserBindingConstants.java
@@ -34,8 +34,6 @@ public class DraytonWiserBindingConstants {
 
     public static final String BINDING_ID = "draytonwiser";
 
-    public static final String ADDRESS = "networkAddress";
-
     public static final String REFRESH_INTERVAL = "refresh";
     public static final int DEFAULT_REFRESH_SECONDS = 60;
 
@@ -63,6 +61,12 @@ public class DraytonWiserBindingConstants {
     public static final ThingTypeUID THING_TYPE_ITRV = new ThingTypeUID(BINDING_ID, "itrv");
     public static final ThingTypeUID THING_TYPE_HOTWATER = new ThingTypeUID(BINDING_ID, "hotwater");
     public static final ThingTypeUID THING_TYPE_SMARTPLUG = new ThingTypeUID(BINDING_ID, "smart-plug");
+
+    // properties
+    public static final String PROP_ADDRESS = "networkAddress";
+    public static final String PROP_SERIAL_NUMBER = "serialNumber";
+    public static final String PROP_NAME = "name";
+    public static final String PROP_ID = "id";
 
     // List of all Channel ids
     public static final String CHANNEL_CURRENT_TEMPERATURE = "currentTemperature";

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/api/DraytonWiserApi.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/api/DraytonWiserApi.java
@@ -208,11 +208,10 @@ public class DraytonWiserApi {
         } catch (final TimeoutException e) {
             failCount++;
             if (failCount > 2) {
-                logger.debug("Heathub didn't repond in time: {}", e.getMessage(), e);
+                logger.debug("Heathub didn't repond in time: {}", e.getMessage());
                 throw new DraytonWiserApiException("Heathub didn't repond in time", e);
             }
         } catch (final InterruptedException e) {
-            logger.debug("Interrupted: {}", e.getMessage(), e);
             Thread.currentThread().interrupt();
         } catch (final ExecutionException e) {
             logger.debug("Execution Exception: {}", e.getMessage(), e);

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserMDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserMDNSDiscoveryParticipant.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.draytonwiser.internal.discovery;
 
+import static org.openhab.binding.draytonwiser.internal.DraytonWiserBindingConstants.*;
+
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +29,6 @@ import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.mdns.MDNSDiscoveryParticipant;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.openhab.binding.draytonwiser.internal.DraytonWiserBindingConstants;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryPartic
 
     @Override
     public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
-        return Collections.singleton(DraytonWiserBindingConstants.THING_TYPE_BRIDGE);
+        return Collections.singleton(THING_TYPE_BRIDGE);
     }
 
     @Override
@@ -66,13 +67,12 @@ public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryPartic
                 final InetAddress[] addresses = service.getInetAddresses();
 
                 if (addresses.length > 0 && addresses[0] != null) {
-                    properties.put(DraytonWiserBindingConstants.ADDRESS, addresses[0].getHostAddress());
-                    properties.put(DraytonWiserBindingConstants.REFRESH_INTERVAL,
-                            DraytonWiserBindingConstants.DEFAULT_REFRESH_SECONDS);
+                    properties.put(PROP_ADDRESS, addresses[0].getHostAddress());
+                    properties.put(REFRESH_INTERVAL, DEFAULT_REFRESH_SECONDS);
                 }
 
                 return DiscoveryResultBuilder.create(uid).withProperties(properties)
-                        .withRepresentationProperty(uid.getId()).withLabel("Heat Hub - " + service.getName()).build();
+                        .withRepresentationProperty(PROP_ADDRESS).withLabel("Heat Hub - " + service.getName()).build();
             }
         }
         return null;
@@ -83,7 +83,7 @@ public class DraytonWiserMDNSDiscoveryParticipant implements MDNSDiscoveryPartic
         if (service.getType() != null && service.getType().equals(getServiceType())
                 && service.getName().contains("WiserHeat")) {
             logger.trace("Discovered a Drayton Wiser Heat Hub thing with name '{}'", service.getName());
-            return new ThingUID(DraytonWiserBindingConstants.THING_TYPE_BRIDGE, service.getName());
+            return new ThingUID(THING_TYPE_BRIDGE, service.getName());
         }
         return null;
     }

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/DraytonWiserPropertyHelper.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/DraytonWiserPropertyHelper.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.draytonwiser.internal.handler;
 
+import static org.openhab.binding.draytonwiser.internal.DraytonWiserBindingConstants.PROP_SERIAL_NUMBER;
+
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -29,12 +31,8 @@ public final class DraytonWiserPropertyHelper {
         // helper class
     }
 
-    public static void setControllerProperties(final DeviceDTO device, final Map<String, Object> properties) {
-        setGeneralDeviceProperties(device, properties);
-    }
-
     public static void setPropertiesWithSerialNumber(final DeviceDTO device, final Map<String, Object> properties) {
-        properties.put("serialNumber", device.getSerialNumber());
+        properties.put(PROP_SERIAL_NUMBER, device.getSerialNumber());
         setGeneralDeviceProperties(device, properties);
     }
 

--- a/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomHandler.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/java/org/openhab/binding/draytonwiser/internal/handler/RoomHandler.java
@@ -14,7 +14,6 @@ package org.openhab.binding.draytonwiser.internal.handler;
 
 import static org.openhab.binding.draytonwiser.internal.DraytonWiserBindingConstants.*;
 
-import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Time;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -61,7 +60,7 @@ public class RoomHandler extends DraytonWiserThingHandler<RoomDTO> {
         switch (channelId) {
             case CHANNEL_CURRENT_SETPOINT:
                 if (command instanceof QuantityType) {
-                    setSetPoint((QuantityType<Temperature>) command);
+                    setSetPoint((QuantityType<?>) command);
                 }
                 break;
             case CHANNEL_MANUAL_MODE_STATE:
@@ -105,9 +104,9 @@ public class RoomHandler extends DraytonWiserThingHandler<RoomDTO> {
         return new QuantityType<>(getData().getCurrentSetPoint() / 10.0, SIUnits.CELSIUS);
     }
 
-    private void setSetPoint(final QuantityType<Temperature> command) throws DraytonWiserApiException {
+    private void setSetPoint(final QuantityType<?> command) throws DraytonWiserApiException {
         if (getData().getId() != null) {
-            final QuantityType<Temperature> value = command.toUnit(SIUnits.CELSIUS);
+            final QuantityType<?> value = command.toUnit(SIUnits.CELSIUS);
 
             if (value != null) {
                 final int newSetPoint = (int) Math.round(value.doubleValue() * 10);

--- a/bundles/org.openhab.binding.draytonwiser/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.draytonwiser/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -8,7 +8,8 @@
 	<bridge-type id="heathub">
 		<label>HeatHub</label>
 		<description>A Drayton Wiser HeatHub acting as a bridge to Thermostats and TRVs</description>
-		<representation-property>serialNumber</representation-property>
+
+		<representation-property>networkAddress</representation-property>
 
 		<config-description>
 			<parameter name="networkAddress" type="text" required="true">
@@ -62,6 +63,8 @@
 			<channel id="currentSignalStrength" typeId="system.signal-strength"/>
 			<channel id="currentWiserSignalStrength" typeId="wiserSignalStrength-channel"/>
 		</channels>
+
+		<representation-property>id</representation-property>
 	</thing-type>
 
 	<!-- Hot Water Thing Type -->
@@ -89,6 +92,8 @@
 			</channel>
 			<channel id="hotWaterBoostRemaining" typeId="boostRemaining-channel"/>
 		</channels>
+
+		<representation-property>id</representation-property>
 	</thing-type>
 
 	<!-- Room Thing Type -->
@@ -117,6 +122,8 @@
 			<channel id="windowStateDetection" typeId="windowStateDetection-channel"/>
 			<channel id="windowState" typeId="windowState-channel"/>
 		</channels>
+
+		<representation-property>name</representation-property>
 
 		<config-description>
 			<parameter name="name" type="text" required="true">
@@ -150,6 +157,8 @@
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 		</channels>
 
+		<representation-property>serialNumber</representation-property>
+
 		<config-description>
 			<parameter name="serialNumber" type="text" required="true">
 				<label>Serial Number</label>
@@ -182,6 +191,8 @@
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 		</channels>
 
+		<representation-property>serialNumber</representation-property>
+
 		<config-description>
 			<parameter name="serialNumber" type="text" required="true">
 				<label>Serial Number</label>
@@ -198,6 +209,7 @@
 
 		<label>Smart Plug</label>
 		<description>Remote controlled Plug Socket</description>
+
 		<channels>
 			<channel id="plugOutputState" typeId="plugOutputState-channel"/>
 			<channel id="plugAwayAction" typeId="plugAwayAction-channel"/>
@@ -207,6 +219,8 @@
 			<channel id="deviceLocked" typeId="deviceLocked-channel"/>
 			<channel id="manualModeState" typeId="manualModeState-channel"/>
 		</channels>
+
+		<representation-property>serialNumber</representation-property>
 
 		<config-description>
 			<parameter name="serialNumber" type="text" required="true">

--- a/bundles/org.openhab.binding.draytonwiser/src/test/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.draytonwiser/src/test/java/org/openhab/binding/draytonwiser/internal/discovery/DraytonWiserDiscoveryServiceTest.java
@@ -78,7 +78,7 @@ public class DraytonWiserDiscoveryServiceTest {
 
     @Parameters(name = "{0}")
     public static List<Object[]> data() {
-        return Arrays.asList(new Object[] { "../test1.json", 10 }, new Object[] { "../test2.json", 22 });
+        return Arrays.asList(new Object[] { "../test1.json", 11 }, new Object[] { "../test2.json", 22 });
     }
 
     @Before


### PR DESCRIPTION
- Added missing representation property to thing xml file
- Changed representation property of bridge to network address because serialnumber is not know at discovery time.
- Added id as representation property to controller. To find only 1 controller if the user uses a  different thinguid as the discovery.
- Fixed hot water thing discovery. It doesn't have a serial number and also no related to a device.
- Improved the readme formatting.
- And some other review comments.